### PR TITLE
chore: enable expressive-code collapsible-sections and line-numbers plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ pnpm-debug.log*
 
 # macOS-specific files
 .DS_Store
+
+# Claude Code per-machine settings
+.claude/settings.local.json

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,6 +1,8 @@
 import mdx from '@astrojs/mdx'
 import sitemap from '@astrojs/sitemap'
 import tailwindcss from '@tailwindcss/vite'
+import { pluginCollapsibleSections } from '@expressive-code/plugin-collapsible-sections'
+import { pluginLineNumbers } from '@expressive-code/plugin-line-numbers'
 import compress from 'astro-compress'
 import critters from 'astro-critters'
 import expressiveCode from 'astro-expressive-code'
@@ -25,6 +27,16 @@ export default defineConfig({
       themes: ['dark-plus', 'one-light'],
       useDarkModeMediaQuery: true,
       //themeCssSelector: (theme) => `:root[data-theme="${theme.type}"]`,
+      plugins: [pluginCollapsibleSections(), pluginLineNumbers()],
+      defaultProps: {
+        // Line numbers off by default. Opt in per block with showLineNumbers.
+        showLineNumbers: false,
+      },
+      styleOverrides: {
+        collapsibleSections: {
+          closedBackgroundColor: 'rgba(127, 127, 127, 0.08)',
+        },
+      },
     }),
     mdx(),
   ],

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.5.1",
+    "@expressive-code/plugin-collapsible-sections": "^0.41.7",
+    "@expressive-code/plugin-line-numbers": "^0.41.7",
     "@tailwindcss/vite": "^4.2.4",
     "prettier": "^3.1.1",
     "prettier-plugin-astro": "^0.12.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,12 @@ importers:
       '@biomejs/biome':
         specifier: 1.5.1
         version: 1.5.1
+      '@expressive-code/plugin-collapsible-sections':
+        specifier: ^0.41.7
+        version: 0.41.7
+      '@expressive-code/plugin-line-numbers':
+        specifier: ^0.41.7
+        version: 0.41.7
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.19.3)(yaml@2.5.0))
@@ -713,8 +719,14 @@ packages:
   '@expressive-code/core@0.41.7':
     resolution: {integrity: sha512-ck92uZYZ9Wba2zxkiZLsZGi9N54pMSAVdrI9uW3Oo9AtLglD5RmrdTwbYPCT2S/jC36JGB2i+pnQtBm/Ib2+dg==}
 
+  '@expressive-code/plugin-collapsible-sections@0.41.7':
+    resolution: {integrity: sha512-uh74qWhAW6FEoNdlQAcHCcGBfuhslLvbWL5Fqmi+db/9mZI/I2G1Sr8NfApTEzD+jiIB/GmdPHV9kbjebkn0+g==}
+
   '@expressive-code/plugin-frames@0.41.7':
     resolution: {integrity: sha512-diKtxjQw/979cTglRFaMCY/sR6hWF0kSMg8jsKLXaZBSfGS0I/Hoe7Qds3vVEgeoW+GHHQzMcwvgx/MOIXhrTA==}
+
+  '@expressive-code/plugin-line-numbers@0.41.7':
+    resolution: {integrity: sha512-wI9D5NBcgE9ksiJJV8YfOC0RPI3283+9AYWIb8pBUM5TSM8msIs1YRPDt8c8Ub0XGQvbjJKtB+f9fAl2RiHJ2A==}
 
   '@expressive-code/plugin-shiki@0.41.7':
     resolution: {integrity: sha512-DL605bLrUOgqTdZ0Ot5MlTaWzppRkzzqzeGEu7ODnHF39IkEBbFdsC7pbl3LbUQ1DFtnfx6rD54k/cdofbW6KQ==}
@@ -4775,7 +4787,15 @@ snapshots:
       unist-util-visit: 5.0.0
       unist-util-visit-parents: 6.0.2
 
+  '@expressive-code/plugin-collapsible-sections@0.41.7':
+    dependencies:
+      '@expressive-code/core': 0.41.7
+
   '@expressive-code/plugin-frames@0.41.7':
+    dependencies:
+      '@expressive-code/core': 0.41.7
+
+  '@expressive-code/plugin-line-numbers@0.41.7':
     dependencies:
       '@expressive-code/core': 0.41.7
 


### PR DESCRIPTION
## Summary

- Adds `@expressive-code/plugin-collapsible-sections` and `@expressive-code/plugin-line-numbers` as devDependencies.
- Wires both plugins into `astro.config.ts` inside the existing `expressiveCode({...})` block. `defaultProps.showLineNumbers` is set to `false`, so every existing post renders unchanged; individual posts opt in per code block via `showLineNumbers` / `collapse={X-Y}` meta strings.
- Ignores `.claude/settings.local.json` (per-machine Claude Code settings) so it stops leaking into PRs.

## Why now

The next blog post (#185) leans on `collapse={...}` and `showLineNumbers` annotations, but the plugin install really belongs at site level rather than buried in a content PR. Splitting it out keeps the article PR focused on prose and assets.

## Test plan

- [ ] `pnpm install && pnpm build` — expect 339 pages built, no errors.
- [ ] Spot-check a couple of existing posts (e.g. `2026-03-28_farewell-fullstack-bulletin`, `2025-12-17_debugging-api-gateway-http-oidc-jwt-authorizer`): no line numbers should appear, no layout shift.
- [ ] Confirm `.claude/settings.local.json` is now ignored (`git check-ignore -v .claude/settings.local.json` if the file exists locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)